### PR TITLE
fix: message generation validation logic in chatcompletions

### DIFF
--- a/chapter2/interfaces/chatcompletions_interface.py
+++ b/chapter2/interfaces/chatcompletions_interface.py
@@ -143,7 +143,7 @@ class ChatCompletionsInterface(AbstractInterface):
                 config.em,
                 async_generator_to_reusable_async_iterable(messages_iterator),
             ):
-                if reply_message.name == config.em.name and isempty(
+                if reply_message.author.name == config.em.name and not isempty(
                     reply_message.content
                 ):
                     valid_messages.append(reply_message)


### PR DESCRIPTION
simple change, a prior commit a while back dropped the 'not' and forgot to include the author property.